### PR TITLE
Fix incorrect explanation of pointers from stack to calldata lookup types

### DIFF
--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -8,11 +8,16 @@ location](#user-content-types-overview-overview-of-the-types-direct-types-basics
 padded to a full word in the manner described in the [direct types
 table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).
 
-The one special case here that must be noted here is external functions.  An
+There are two special cases that must be noted here, that each take up two words
+instead of one.  The first special case is that of external functions.  An
 external function is represented by a 20-byte address and a 4-byte selector;
 these are stored in two separate words, with the address in the bottom word and
 the selector in the top word.  Both these are zero-padded on the *left*, not the
 right [like in the other padded locations](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).
+
+The second two-word special case is that of pointers to calldata lookup types;
+see the section on [pointers to calldata from the
+stack](#user-content-locations-in-detail-calldata-in-detail-pointers-to-calldata-pointers-to-calldata-from-the-stack) for details.
 
 The stack is a bit unpredictable in terms of data layout, as it's also used as
 working space.  However, the location of local variables can be figured out by
@@ -177,22 +182,22 @@ digression and discuss pointers to calldata.
 
 #### Pointers to calldata
 
-Pointers to calldata are different depending on whether they are from the stack
-or from calldata.
+Pointers to calldata are different depending on whether they are from calldata
+or from the stack; and pointers to calldata from the stack are different
+depending on whether they point to a multivalue type (i.e. a `type[n]`) or to a
+lookup type.
 
-Pointers to calldata from the stack work like [pointers to
-memory](#user-content-locations-in-detail-memory-in-detail-pointers-to-memory): They are absolute, given in bytes, and always
-point to the start of a word.  In calldata, though, the [start of a
-word](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset) is congruent to `0x4` modulo `0x20`,
-rather than being a multiple of `0x20`.  There is also no need for any sort of
-[null pointer](#user-content-locations-in-detail-memory-in-detail-pointers-to-memory) in calldata, and so no equivalent exists.
+Note, by the way, that there is no need for any sort of
+[null pointer](#user-content-locations-in-detail-pointers-to-memory) in calldata, and so no equivalent exists.
 (Variables in calldata of lookup type may be empty, of course, but distinct
 empty calldata variables are kept separate from another, not coalesced into a
 single null location like in memory.)
 
-Pointers to calldata from calldata, on the other hand, are relative, though in a
-slightly unusual manner.  They are also given in bytes, but are relative not to
-the current location, but rather to the [structure they are a part
+#### Pointers to calldata from calldata
+
+Pointers to calldata from calldata are relative, though in a slightly unusual
+manner.  They are also given in bytes, but are relative not to the current
+location, but rather to the [structure they are a part
 of](#user-content-locations-in-detail-calldata-in-detail-calldata-multivalue-and-lookup-types-reference-types) (since they never
 stand alone.)
 
@@ -208,6 +213,24 @@ list of elements it is contained in.
 Note that pointers to calldata from calldata will always be multiples of `0x20`,
 since calldata, like memory, is padded (and these pointers are relative rather
 than absolute).
+
+#### Pointers to calldata from the stack
+
+Pointers to a `type[n] calldata` (the only legal multivalue type in calldata,
+presently) from the stack work like [pointers to memory](#user-content-locations-in-detail-pointers-to-memory):
+They are absolute, given in bytes, and always point to the start of a word.  In
+calldata, though, the [start of a word](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset)
+is congruent to `0x4` modulo `0x20`, rather than being a multiple of `0x20`.
+
+Pointers to calldata lookup types from the stack take up two words on the stack
+rather than just one.  The bottom word is a pointer -- absolute and given in
+bytes -- but points not to the word containing the length, but rather the start
+of the content, i.e., the word after the length (as described in the section on
+[lookup types in memory](#user-content-locations-in-detail-memory-in-detail-memory-lookup-types)), since [lookup types in
+calldata](#user-content-locations-in-detail-calldata-in-detail-calldata-multivalue-and-lookup-types-reference-types) are
+similar).  The top word contains the length.  Note, obviously, that if the length is
+zero then the value of the pointer is irrelevant (and the word it points to may
+contain unrelated data).
 
 ### Storage in detail
 {"gitdown": "scroll-up", "upRef": "#user-content-locations-in-detail", "upTitle": "Back to Locations in Detail"}

--- a/src/types.md
+++ b/src/types.md
@@ -55,10 +55,12 @@ The stack can hold only direct types and pointer types.
 
 Directly pointed-to variables living in memory or calldata can only be of
 reference type, although their elements, also living in memory or calldata, can
-of course also be of direct or pointer type.  Note that some direct types are
-not allowed in calldata.  (Indeed, calldata has additional retrictions if
-`ABIEncoderV2` is not being used, but we will assume it is, since we want to be
-able to decode whatever people might choose to encode.)
+of course also be of direct or pointer type.
+
+Some types are not allowed in calldata, especially if `ABIEncoderV2` is not
+being used; but we will assume it is, and even describe some things that are not
+supported by Solidity at all yet, since we want to be able to decode whatever
+people might choose to encode.
 
 In addition, the locations memory and calldata may not hold mappings, which may
 go only in storage.  (However, structs that *contain* mappings can go in memory,
@@ -81,12 +83,12 @@ mentioned above):
 
 #### Table of types and locations
 
-| Location | Direct types                                       | Multivalue types      | Lookup types            | Mappings in structs are... | Pointer types                                 |
-|----------|----------------------------------------------------|-----------------------|-------------------------|----------------------------|-----------------------------------------------|
-| Stack    | Yes                                                | No (only as pointers) | No (only as pointers)   | N/A                        | To storage, memory, or calldata               |
-| Storage  | Yes                                                | Yes                   | Yes                     | Legal                      | No                                            |
-| Memory   | Only as elements of other types                    | Yes                   | Yes, excluding mappings | Omitted                    | To memory (only as elements of other types)   |
-| Calldata | Only as elements of other types, with restrictions | Yes                   | Yes, excluding mappings | Illegal                    | To calldata (only as elements of other types) |
+| Location | Direct types                                       | Multivalue types       | Lookup types            | Mappings in structs are... | Pointer types                                 |
+|----------|----------------------------------------------------|------------------------|-------------------------|----------------------------|-----------------------------------------------|
+| Stack    | Yes                                                | No (only as pointers)  | No (only as pointers)   | N/A                        | To storage, memory, or calldata               |
+| Storage  | Yes                                                | Yes                    | Yes                     | Legal                      | No                                            |
+| Memory   | Only as elements of other types                    | Yes                    | Yes, excluding mappings | Omitted                    | To memory (only as elements of other types)   |
+| Calldata | Only as elements of other types, with restrictions | Yes, excluding structs | Yes, excluding mappings | Illegal                    | To calldata (only as elements of other types) |
 
 ### Overview of the types: Direct types
 {"gitdown": "scroll-up", "upRef": "#user-content-types-overview", "upTitle": "Back to Types Overview"}
@@ -274,9 +276,11 @@ deleted -- but we will not go into that here.
 ### Overview of the types: Pointer types
 {"gitdown": "scroll-up", "upRef": "#user-content-types-overview", "upTitle": "Back to Types Overview"}
 
-Pointers always take up a full word.  See the appropriate location section for
-information on pointers to that location ([1](#user-content-locations-in-detail-memory-in-detail-pointers-to-memory),
-[2](#user-content-locations-in-detail-calldata-in-detail-pointers-to-calldata), [3](#user-content-locations-in-detail-storage-in-detail-pointers-to-storage)), but you may find a
+Pointers usually take up a single word, although some take up two words. See the
+appropriate location section for information on pointers to that location
+([1](#user-content-locations-in-detail-memory-in-detail-pointers-to-memory),
+[2](#user-content-locations-in-detail-calldata-in-detail-pointers-to-calldata),
+[3](#user-content-locations-in-detail-storage-in-detail-pointers-to-storage)), but you may find a
 [summarizing table](#user-content-types-overview-overview-of-the-types-pointer-types-table-of-pointer-types) below.
 
 Again, remember that pointers are not, in Solidity, an actual type separate from
@@ -304,10 +308,12 @@ it's illegal to delete them.
 
 #### Table of pointer types
 
-| Type                               | Absolute or relative?        | Measured in... | Default value                                                  |
-|------------------------------------|------------------------------|----------------|----------------------------------------------------------------|
-| Pointer to storage                 | Absolute                     | Words          | `0` (may be garbage, don't use!)                               |
-| Pointer to memory                  | Absolute                     | Bytes          | `0x60` for lookup types; no fixed default for multivalue types |
-| Pointer to calldata from the stack | Absolute                     | Bytes          | N/A                                                            |
-| Pointer to calldata from calldata  | Relative (in an unusual way) | Bytes          | N/A                                                            |
+| Type                                           | Absolute or relative?        | Measured in... | Has second word for length? | Default value                                                  |
+|------------------------------------------------|------------------------------|----------------|-----------------------------|----------------------------------------------------------------|
+| Pointer to storage                             | Absolute                     | Words          | No                          | `0` (may be garbage, don't use!)                               |
+| Pointer to memory                              | Absolute                     | Bytes          | No                          | `0x60` for lookup types; no fixed default for multivalue types |
+| Pointer to calldata from calldata              | Relative (in an unusual way) | Bytes          | No                          | N/A                                                            |
+| Pointer to calldata `type[n]` from the stack   | Absolute                     | Bytes          | No                          | N/A                                                            |
+| Pointer to calldata lookup type from the stack | Absolute (with an offset)    | Bytes          | Yes                         | N/A                                                            |
+                                             |
 


### PR DESCRIPTION
It turns out I was quite mistaken about pointers to calldata from the stack.  I had correctly described the behavior for pointers to calldata from the stack for static arrays, but not for dynamic arrays.  These pointers take up two words on the stack, like external functions do!  And they act differently.  Read the document for details.