### PR TITLE
Account for unaligned objects and unpadded bytestrings

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -44,5 +44,5 @@ original value in calldata will always be copied onto the stack before use).
 Obviously the value still exists in calldata, but since no variable points
 there, it's not our concern.
 
-_**Note**: This document pertains to **Solidity v0.5.2**, current as of this
+_**Note**: This document pertains to **Solidity v0.5.3**, current as of this
 writing._

--- a/src/intro.md
+++ b/src/intro.md
@@ -3,7 +3,7 @@ For writers of line debuggers and other debugging-related utilities.
 
 ---
 
-![Solidity storage allocation example layout](storage.svg)
+![Solidity storage allocation example layout](storage.png)
 
 | Author | Harry Altman [@haltman-at] |
 | -----------:|:------------ |

--- a/src/locations.md
+++ b/src/locations.md
@@ -5,20 +5,25 @@ ignore returndata entirely.  There are also some other "special locations" that
 I will mention briefly in the calldata section but will mostly ignore.)
 
 The stack and storage are made of words ("slots"), while memory and calldata are
-made of bytes; however, we will basically ignore this distinction.  We will, for
-the stack and storage, conventionally consider the large end of each word to be
-the earlier (left) end; and, for the other locations, conventionally consider
-the location as divided up into words ("slots") of 32 bytes, with the earlier
-end of each word being the large end.  Or, in other words, everything is
-big-endian (or construed as big-endian) unless stated otherwise.  With this
-convention, we can ignore the distinction between the slot-based locations and
-the byte-based locations.  (My apologies in advance for the abuse of terminology
-that results from this, but I think using this convention here saves more
-trouble than it causes.)
+made of bytes; however, we will use some conventions to ignore this distinction.
+We will, for the stack and storage, conventionally consider the large end of
+each word to be the earlier (left) end; that is to say, everything is big-endian
+unless stated otherwise.
 
-(For calldata, we will actually use a slightly different convention, as
-[detailed later](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset),
-but you can ignore that for now.)
+The other locations we will consider as conventionally divided up into words
+("slots") of 32 bytes each, with the earlier end of each word being the large
+end; however, we will start these slots at the beginning of the object we are
+decoding, and objects do not always start on multiples of `0x20`, so the slot
+boundaries may not be the conventional ones.  In any case, regardless of the
+starting point, everything is construed as big-endian unless stated otherwise.
+
+With these conventions, we can ignore the distinction between the slot-based
+locations and the byte-based locations.  (My apologies in advance for the abuse
+of terminology that results from this, but I think using these conventions here
+saves more trouble than it causes.)
+
+(For what its worth, objects in calldata always start at a [4-byte
+offset](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset) from a multiple of `0x20`.)
 
 Memory and calldata will always be accessed through pointers to such; as such,
 we will only discuss concrete data layout for storage and (a little bit) for the

--- a/src/types.md
+++ b/src/types.md
@@ -108,9 +108,9 @@ will be described in more detail later ([1](#user-content-locations-in-detail-me
 [2](#user-content-locations-in-detail-the-stack-in-some-detail)).)  The exact method of padding varies by type,
 as detailed in [the table below](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).
 
-(Again, note that for calldata we are using a somewhat unusual notion of slot;
-[see the calldata section](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset) for more
-information.)
+(Again, note that slots in memory and calldata are [always relative to the
+beginning of the object being decoded](#user-content-the-locations-basics), and not based on
+absolute multiples of `0x20`.)
 
 #### Table of direct types
 


### PR DESCRIPTION
Solidity 0.5.3 adds the possibility of unpadded bytestrings in memory, or, in other words, the possibility of unaligned objects in memory.  I've made a few changes to account for this.