### PR TITLE
Alignment bug

### DIFF
--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -39,6 +39,14 @@ We won't discuss layout in memory since, as mentioned, we only access it via
 pointers.  We'll break this down into sections depending on what type of
 variable we're looking at.
 
+*Remark*: Although memory objects ordinarily start on a word, there is a bug in
+version 0.5.3 of Solidity specifically that can occasionally cause them to
+start in the middle of a word.  In this case, for the purposes of decoding that
+object, you should consider slots to begin at the beginning of that object. (Of
+course, once you follow a pointer, you'll have to have your slots based on that
+pointer.  Again, since we only access memory through pointers, this is mostly
+not a concern, and it only happens at all in that one version of Solidity.)
+
 #### Memory: Direct types and pointer types
 
 Memory is a [padded location](#user-content-types-overview-overview-of-the-types-direct-types-basics-of-direct-types-packing-and-padding), so
@@ -80,10 +88,16 @@ string are *not* individually padded, but rather are simply stored in sequence.
 Since the last slot may not contain a full 32 bytes, it is zero-padded on the
 right.
 
+*Remark*: In Solidity version 0.5.3 specifically, there is a bug that can cause
+some `bytes` to lack the padding on the end, resulting in the alignment bug
+[mentioned above](#user-content-locations-in-detail-memory-in-detail).
+
+
 #### Pointers to memory
 
 Pointers to memory are absolute and given in bytes.  Since memory is padded, all
 pointers will point to the start of a word and thus be a multiple of `0x20`.
+(With the exception, [mentioned above](#user-content-locations-in-detail-memory-in-detail), of some pointers in Solidity v0.5.3.)
 
 The pointer `0x60` is something of a null pointer; it points to a reserved slot
 which is always zero.  By the previous section, this slot can therefore

--- a/src/locations.md
+++ b/src/locations.md
@@ -18,7 +18,9 @@ trouble than it causes.)
 
 (For calldata, we will actually use a slightly different convention, as
 [detailed later](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset),
-but you can ignore that for now.)
+but you can ignore that for now.  We will also occasionally use a different
+convention in memory, as [also detailed later](#user-content-locations-in-detail-locations-in-detail), but you can again ignore that
+for now.)
 
 Memory and calldata will always be accessed through pointers to such; as such,
 we will only discuss concrete data layout for storage and (a little bit) for the

--- a/src/locations.md
+++ b/src/locations.md
@@ -19,7 +19,7 @@ trouble than it causes.)
 (For calldata, we will actually use a slightly different convention, as
 [detailed later](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset),
 but you can ignore that for now.  We will also occasionally use a different
-convention in memory, as [also detailed later](#user-content-locations-in-detail-locations-in-detail-memory-in-detail), but you can again ignore that
+convention in memory, as [also detailed later](#user-content-locations-in-detail-memory-in-detail), but you can again ignore that
 for now.)
 
 Memory and calldata will always be accessed through pointers to such; as such,

--- a/src/locations.md
+++ b/src/locations.md
@@ -19,7 +19,7 @@ trouble than it causes.)
 (For calldata, we will actually use a slightly different convention, as
 [detailed later](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset),
 but you can ignore that for now.  We will also occasionally use a different
-convention in memory, as [also detailed later](#user-content-locations-in-detail-locations-in-detail), but you can again ignore that
+convention in memory, as [also detailed later](#user-content-locations-in-detail-locations-in-detail-memory-in-detail), but you can again ignore that
 for now.)
 
 Memory and calldata will always be accessed through pointers to such; as such,


### PR DESCRIPTION
Earlier I reverted the notes about unaligned objects in memory.  I'm adding them back in, but noting that they're a bug in Solidity 0.5.3 specifically, not reworking things to account for them.