### PR TITLE
Update for 0.7.1

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -26,9 +26,9 @@ is not entirely predictable but may be determined by other
 systems of the debugger, we may rely on that.  See the
 [Solidity documentation](https://solidity.readthedocs.io/) for things not
 covered here, particularly the
-[section on types](https://solidity.readthedocs.io/en/v0.5.2/solidity-in-depth.html),
-the [ABI specification](https://solidity.readthedocs.io/en/v0.5.2/abi-spec.html),
-and the [miscellaneous section](https://solidity.readthedocs.io/en/v0.5.2/miscellaneous.html);
+[section on types](https://solidity.readthedocs.io/en/v0.7.1/solidity-in-depth.html),
+the [ABI specification](https://solidity.readthedocs.io/en/v0.7.1/abi-spec.html),
+and the [miscellaneous section](https://solidity.readthedocs.io/en/v0.7.1/miscellaneous.html);
 and perhaps also see the [Ethereum yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf).
 
 This document is also primarily only concerned with variables that a user might
@@ -45,5 +45,5 @@ original value in calldata will always be copied onto the stack before use).
 Obviously the value still exists in calldata, but since no variable points
 there, it's not our concern.
 
-_**Note**: This document pertains to **Solidity v0.6.3**, current as of this
+_**Note**: This document pertains to **Solidity v0.7.1**, current as of this
 writing._

--- a/src/intro.md
+++ b/src/intro.md
@@ -8,7 +8,7 @@ For writers of line debuggers and other debugging-related utilities.
 | Author | Harry Altman [@haltman-at] |
 | -----------:|:------------ |
 | Published | 2018-12-26 - Boxing Day |
-| Last revised | 2020-03-04 |
+| Last revised | 2020-09-08 |
 | Copyright | 2018-2019 Truffle Blockchain Group |
 | License | <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a> |
 | Document Source | [ethdebug/solidity-data-representation](https://github.com/ethdebug/solidity-data-representation) |

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -129,7 +129,7 @@ As such, each (non-mapping) element takes up exactly one word (because direct
 types are padded and all reference types are stored as pointers).  Elements of
 structs go in the order they're specified in.
 
-(Note that prior to Solidity 0.6.0 it was possible to have in memory a struct
+(Note that prior to Solidity 0.7.0 it was possible to have in memory a struct
 that contains *only* mappings, and prior to 0.5.0, it was possible to have a
 struct that was empty entirely, or a statically-sized array of length 0.  Such
 a struct or array doesn't really have a representation in memory, since in

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -35,10 +35,10 @@ The stack is of course not used only for storing local variables, but also as a
 working space.  And of course it also holds return addresses.  The stack is
 divided into stackframes; each stackframe begins with the return address.
 (There is no frame pointer, for those used to such a thing; just a return
-address.)  The exceptions are constructors and fallback functions, which do not
+address.)  The exceptions are constructors and fallback/receive functions, which do not
 include a return address.  In addition, if the initial function call (i.e.
 stackframe) of the EVM stackframe (i.e. message call or creation call) is not a
-constructor or fallback function, the function selector will be stored on the
+constructor or fallback/receive function, the function selector will be stored on the
 stack below the first stackframe.  (Additionally, in Solidity 0.4.20 and later,
 an extra zero word will appear below that on the stack if you're within a library
 call.)
@@ -65,6 +65,9 @@ exits.  It's necessary here to specify the order they go onto the stack.  First
 come the input parameters, in the order they were given, followed by the output
 parameters, in the order they were given.  Anonymous output parameters are
 treated the same as named output parameters for these purposes.
+
+*Remark*: Yul functions work slightly differently here, in that output parameters
+are pushed onto the stack in the *reverse* of the order they were given.
 
 Ordinary local variables, as declared in a function or modifier, are pushed
 onto the stack at their declaration and are popped when their containing block
@@ -94,6 +97,11 @@ parameters are pushed on in order from left to right.  Constructors then
 execute in order from most base to most derived (again, note that the order
 they're listed on the constructor declaration has no effect); when a
 constructor exits, its parameters are popped from the stack.
+
+Paramters to a modifier on a fallback or receive function work like parameters
+to a modifier on any other function.  Note that parameters to a modifier on a
+constructor only go onto the stack when that particular constructor is about to
+run (i.e., all base constructors that run before it have exited).
 
 ### Memory in detail
 {"gitdown": "scroll-up", "upRef": "#user-content-locations-in-detail", "upTitle": "Back to Locations in Detail"}

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -123,10 +123,11 @@ representation of its elements; with the exceptions that elements of reference
 type (both multivalue and lookup types), other than mappings, are [represented
 as
 pointers](#user-content-locations-in-detail-memory-in-detail-pointers-to-memory).
-(Also, prior to Solidity 0.5.0, elements of `mapping` type were allowed in
-memory structs and were simply omitted, as mappings cannot appear in memory.)
-As such, each (non-mapping) element takes up exactly one word (because direct
-types are padded and all reference types are stored as pointers).  Elements of
+(Also, prior to Solidity 0.7.0, elements of `mapping` type, as well as
+(possibly multidimensional) arrays of such, were allowed in memory structs and
+were simply omitted, as mappings cannot appear in memory.) As such, each
+element (that isn't omitted) takes up exactly one word (because direct types
+are padded and all reference types are stored as pointers).  Elements of
 structs go in the order they're specified in.
 
 (Note that prior to Solidity 0.7.0 it was possible to have in memory a struct
@@ -230,8 +231,8 @@ inline; so unlike in memory, elements may take up multiple words.  Elements of
 dynamic type are still stored as pointers (but see the [section
 below](#user-content-locations-in-detail-calldata-in-detail-pointers-to-calldata) about how those work).
 
-Also, structs that contain mappings are entirely illegal in calldata, unlike
-in memory where the mappings are simply omitted.
+Also, structs that contain mappings (or arrays of such) are entirely illegal in
+calldata, unlike in memory where the mappings are simply omitted.
 
 *Remark*: Calldata variables were only introduced in Solidity 0.5.0, so it is
 impossible to have variables of zero-element multivalue type in calldata;

--- a/src/locations.md
+++ b/src/locations.md
@@ -1,28 +1,30 @@
 The EVM has a number of locations where data can be stored.  We will be
-concerned with four of them: The stack, storage, memory, and calldata.  (We will
-also be incidentally concerned with code, but we will mostly ignore it.  We will
-ignore returndata entirely.  There are also some other "special locations" that
+concerned with five of them: The stack, storage, memory, calldata, and code.
+(We will ignore returndata.  There are also some other "special locations" that
 I will mention briefly in the calldata section but will mostly ignore.)
 
-The stack and storage are made of words ("slots"), while memory and calldata are
-made of bytes; however, we will basically ignore this distinction.  We will, for
-the stack and storage, conventionally consider the large end of each word to be
-the earlier (left) end; and, for the other locations, conventionally consider
-the location as divided up into words ("slots") of 32 bytes, with the earlier
-end of each word being the large end.  Or, in other words, everything is
-big-endian (or construed as big-endian) unless stated otherwise.  With this
+The stack and storage are made of words ("slots"), while memory, calldata, and
+code are made of bytes; however, we will basically ignore this distinction.  We
+will, for the stack and storage, conventionally consider the large end of each
+word to be the earlier (left) end; and, for the other locations, conventionally
+consider the location as divided up into words ("slots") of 32 bytes, with the
+earlier end of each word being the large end.  Or, in other words, everything
+is big-endian (or construed as big-endian) unless stated otherwise.  With this
 convention, we can ignore the distinction between the slot-based locations and
-the byte-based locations.  (My apologies in advance for the abuse of terminology
-that results from this, but I think using this convention here saves more
-trouble than it causes.)
+the byte-based locations.  (My apologies in advance for the abuse of
+terminology that results from this, but I think using this convention here
+saves more trouble than it causes.)
 
 (For calldata, we will actually use a slightly different convention, as
 [detailed later](#user-content-locations-in-detail-calldata-in-detail-slots-in-calldata-and-the-offset),
 but you can ignore that for now.  We will also occasionally use a different
 convention in memory, as [also detailed later](#user-content-locations-in-detail-memory-in-detail), but you can again ignore that
-for now.)
+for now.  Also, we will ignore the notion of "slots" in the case of code.)
 
-Memory and calldata will always be accessed through pointers to such; as such,
-we will only discuss concrete data layout for storage and for the stack, as
-those are the only locations we'll access without a pointer (but for the stack
-we'll mostly rely on the debugger having other ways of determining location).
+Memory (with one exception to be [described
+later](#user-content-locations-in-detail-memory-in-detail)) and calldata will
+always be accessed through pointers to such; as such, we will only discuss
+concrete data layout for storage, the stack, and code, as those are the only
+locations we'll access without a pointer (but for the stack we'll mostly rely
+on the debugger having other ways of determining location, and for code we'll
+rely on other compiler output).

--- a/src/types.md
+++ b/src/types.md
@@ -67,7 +67,7 @@ allowed in calldata.
 
 In addition, the locations memory and calldata may not hold mappings, which may
 go only in storage.  (However, structs that *contain* mappings were allowed in
-memory prior to Solidity 0.6.0, though the mappings would be omitted; see [the
+memory prior to Solidity 0.7.0, though the mappings would be omitted; see [the
 section on
 memory](#user-content-locations-in-detail-memory-in-detail-memory-lookup-types)
 for more detail.)
@@ -96,7 +96,7 @@ mentioned above):
 |----------|----------------------------------------------------|--------------------------------------|-------------------------|----------------------------------|-----------------------------------------------|
 | Stack    | Yes                                                | No (only as pointers)                | No (only as pointers)   | N/A                              | To storage, memory, or calldata               |
 | Storage  | Yes                                                | Yes                                  | Yes                     | Legal                            | No                                            |
-| Memory   | Only as elements of other types                    | Yes                                  | Yes, excluding mappings | Illegal (omitted prior to 0.6.0) | To memory (only as elements of other types)   |
+| Memory   | Only as elements of other types                    | Yes                                  | Yes, excluding mappings | Illegal (omitted prior to 0.7.0) | To memory (only as elements of other types)   |
 | Calldata | Only as elements of other types, with restrictions | Yes, excluding circular struct types | Yes, excluding mappings | Illegal                          | To calldata (only as elements of other types) |
 
 Note that with the exception of the special case of mappings in structs, it is

--- a/src/types.md
+++ b/src/types.md
@@ -66,9 +66,10 @@ being used; but we will assume it is.  Note, though, that circular types are nev
 allowed in calldata.
 
 In addition, the locations memory and calldata may not hold mappings, which may
-go only in storage.  (However, structs that *contain* mappings were allowed in
-memory prior to Solidity 0.7.0, though the mappings would be omitted; see [the
-section on
+go only in storage.  (However, structs that *contain* mappings, or that contain
+(possibly multidimensional) arrays of mappings, were allowed in memory prior to
+Solidity 0.7.0, though such mappings or arrrays would be omitted from the
+struct; see [the section on
 memory](#user-content-locations-in-detail-memory-in-detail-memory-lookup-types)
 for more detail.)
 
@@ -92,16 +93,17 @@ mentioned above):
 
 #### Table of types and locations
 
-| Location | Direct types                                       | Multivalue types                     | Lookup types            | Mappings in structs are...       | Pointer types                                 |
-|----------|----------------------------------------------------|--------------------------------------|-------------------------|----------------------------------|-----------------------------------------------|
-| Stack    | Yes                                                | No (only as pointers)                | No (only as pointers)   | N/A                              | To storage, memory, or calldata               |
-| Storage  | Yes                                                | Yes                                  | Yes                     | Legal                            | No                                            |
-| Memory   | Only as elements of other types                    | Yes                                  | Yes, excluding mappings | Illegal (omitted prior to 0.7.0) | To memory (only as elements of other types)   |
-| Calldata | Only as elements of other types, with restrictions | Yes, excluding circular struct types | Yes, excluding mappings | Illegal                          | To calldata (only as elements of other types) |
+| Location | Direct types                                       | Multivalue types                     | Lookup types            | Mappings and arrays of such in structs are... | Pointer types                                 |
+|----------|----------------------------------------------------|--------------------------------------|-------------------------|-----------------------------------------------|-----------------------------------------------|
+| Stack    | Yes                                                | No (only as pointers)                | No (only as pointers)   | N/A                                           | To storage, memory, or calldata               |
+| Storage  | Yes                                                | Yes                                  | Yes                     | Legal                                         | No                                            |
+| Memory   | Only as elements of other types                    | Yes                                  | Yes, excluding mappings | Illegal (omitted prior to 0.7.0)              | To memory (only as elements of other types)   |
+| Calldata | Only as elements of other types, with restrictions | Yes, excluding circular struct types | Yes, excluding mappings | Illegal                                       | To calldata (only as elements of other types) |
 
-Note that with the exception of the special case of mappings in structs, it is
-otherwise true that if the type of some element of some given type is illegal
-in that location, then so is the type as a whole.
+Note that with the exception of the special case of mappings (or possibly
+multidimensional arrays of such) in structs, it is otherwise true that if the
+type of some element of some given type is illegal in that location, then so is
+the type as a whole.
 
 ### Overview of the types: Direct types
 {"gitdown": "scroll-up", "upRef": "#user-content-types-overview", "upTitle": "Back to Types Overview"}
@@ -255,12 +257,15 @@ specified there.
 *Remark*: Prior to Solidity 0.5.0, it was legal to have `type[0]` or empty
 structs.
 
-Note that it is legal to include a `mapping` type as an element of a `struct`
-type; this does *not* preclude the `struct` type from being used in memory (even
-though, as per the following section, mappings cannot appear in memory), but
-rather, the mapping is simply omitted in memory.  See the [memory
-section](#user-content-locations-in-detail-memory-in-detail-memory-lookup-types) for more details.  Such a struct is barred from
-appearing in calldata, however.
+Note that it is legal to include a `mapping` type, or a (possibly
+multidimensional) array of mappings, as an element of a `struct` type; prior to
+Solidity 0.7.0, this did *not* preclude the `struct` type from being used in
+memory (even though, as per the following section, mappings cannot appear in
+memory), but rather, the mapping (or array) would be simply omitted in memory.
+See the [memory
+section](#user-content-locations-in-detail-memory-in-detail-memory-lookup-types)
+for more details.  Such a struct has always been barred from appearing in
+calldata, however.
 
 Also note that circular struct types are allowed, so long as the circularity is
 mediated by a lookup type.  That is to say, if a struct type `T0` has a element

--- a/src/types.md
+++ b/src/types.md
@@ -361,5 +361,5 @@ it's illegal to delete them.
 | Pointer to storage                                   | Absolute                     | Words          | No                          | `0` (may be garbage, don't use!)                               |
 | Pointer to memory                                    | Absolute                     | Bytes          | No                          | `0x60` for lookup types; no fixed default for multivalue types |
 | Pointer to calldata from calldata                    | Relative (in an unusual way) | Bytes          | No                          | N/A                                                            |
-| Pointer to calldata multivalue type from the stack   | Absolute                     | Bytes          | No                          | N/A                                                            |
-| Pointer to calldata lookup type from the stack       | Absolute (with an offset)    | Bytes          | Yes                         | N/A                                                            |
+| Pointer to calldata multivalue type from the stack   | Absolute                     | Bytes          | No                          | Equal to the length of calldata                                |
+| Pointer to calldata lookup type from the stack       | Absolute (with an offset)    | Bytes          | Yes                         | Equal to the length of calldata, length equal to zero          |


### PR DESCRIPTION
This PR updates this paper for Solidity 0.7.1, as well as correcting various errors and omissions.

You can just read the changes, really, but to sum them up they are:

1. Immutables are now described!  Changes here include a new data location (code), and various stuff added to the memory section to cover them, and also discussions of how they're padded, updates to storage layout description, and a new column on the direct types table... this was the biggest change.
2. Calldata pointers from the stack have default values now.
3. Putting mappings in memory structs didn't become illegal until 0.7.0, oops (I said 0.6.0)
4. Speaking of which, arrays of mappings in memory structs are accounted for now
5. I said a bit more about parameters to modifiers on constructors, fallbacks, and receives
6. Receives are mentioned
7. Solidity documentation links are updated
8. Oh and also I mentioned how Yul functions do their output parameters differently from Solidity functions