### PR TITLE
Updates for Solidity 0.8.8 and 0.8.9

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -8,8 +8,8 @@ For writers of line debuggers and other debugging-related utilities.
 | Author | Harry Altman [@haltman-at] |
 | -----------:|:------------ |
 | Published | 2018-12-26 - Boxing Day |
-| Last revised | 2021-09-13 |
-| Copyright | 2018-2021 Truffle Blockchain Group |
+| Last revised | 2021-10-01 |
+| Copyright | 2018-2021 ConsenSys Software Inc |
 | License | <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a> |
 | Document Source | [ethdebug/solidity-data-representation](https://github.com/ethdebug/solidity-data-representation) |
 
@@ -26,8 +26,8 @@ is not entirely predictable but may be determined by other
 systems of the debugger, we may rely on that.  See the
 [Solidity documentation](https://docs.soliditylang.org/) for things not
 covered here, particularly the
-[section on types](https://docs.soliditylang.org/en/v0.8.7/types.html)
-and the [ABI specification](https://docs.soliditylang.org/en/v0.8.7/types.html);
+[section on types](https://docs.soliditylang.org/en/v0.8.9/types.html)
+and the [ABI specification](https://docs.soliditylang.org/en/v0.8.9/types.html);
 and perhaps also see the [Ethereum yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf).
 
 This document is also primarily only concerned with variables that a user might
@@ -44,5 +44,5 @@ original value in calldata will always be copied onto the stack before use).
 Obviously the value still exists in calldata, but since no variable points
 there, it's not our concern.
 
-_**Note**: This document pertains to **Solidity v0.8.7**, current as of this
+_**Note**: This document pertains to **Solidity v0.8.9**, current as of this
 writing._

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -165,7 +165,7 @@ Memory is a [padded location](#user-content-types-overview-overview-of-the-types
 direct types are padded as [described in their table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).
 Pointers, as mentioned above, always take up a full word.
 
-Note that prior to Solidity 0.8.9, immutables stored in memory had unusual
+**Note that prior to Solidity 0.8.9**, immutables stored in memory had unusual
 padding; they were always zero-padded on the right, regardless of their usual
 padding.  Again, note that this only applied to immutables stored directly in
 memory during contract construct, and not to direct types appearing as elements

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -536,12 +536,12 @@ what keys exist; keys that don't exist and keys whose corresponding element is
 For a mapping `map` and a key `key`, then, the element `map[key]` is stored
 starting at `keccak256(key . p)`, where `.` represents concatenation and `key`
 here has been converted to a string of bytes -- something that is meaningful
-for every [elementary type](#user-content-types-overview-overview-of-the-types-lookup-types) (the
-legal key types).  For the elementary types which are direct, the padded form
+for every [key type](#user-content-types-overview-overview-of-the-types-lookup-types).
+For the key types which are direct, the padded form
 is used; the value can be converted to a string of bytes by the representations
 listed in the [section on direct types](#user-content-types-overview-overview-of-the-types-direct-types-representations-of-direct-types),
 with the padding as listed in the [direct types table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types);
-for the lookup elementary type `bytes` ([and `string`](#user-content-types-overview-overview-of-the-types-lookup-types)),
+for the lookup key type `bytes` ([and `string`](#user-content-types-overview-overview-of-the-types-lookup-types)),
 well, this by itself represents a string of bytes!  (No padding is applied to
 these.)  Similarly, the position `p` is regarded as a 32-byte unsigned integer,
 because that is how storage locations are accessed.

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -476,7 +476,7 @@ The layout of direct types has already been described
 [direct types table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).  Note that there are [no pointer
 types in storage](#user-content-types-overview-overview-of-the-types-pointer-types).
 
-Note that in Solidity 0.8.8, there was a bug that caused user-defined value
+**Note that in Solidity 0.8.8**, there was a bug that caused user-defined value
 types to always take up a full word in storage, regardless of the size of the
 underlying type; values of these types would be padded as normal.
 

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -121,10 +121,11 @@ Once a contract has been deployed, its immutable state variables are stored in i
 Only direct types may go in code as immutables.  In addition, `function external`
 variables are currently barred from being used as immutables.
 
-Note that while code is a padded location, its padding works slightly unusually.
-In code, all types are zero-padded, even if ordinarily they would be sign-padded.
-Note that this does not alter whether they are padded on the right or on the left;
-that is still as normal.
+Note that while code is a padded location, prior to Solidity 0.8.9, its padding
+worked a bit unusually.  In code, all types would be zero-padded, even if
+ordinarily they would be sign-padded.  Note that this did not alter whether
+they are padded on the right or on the left.  Since Solidity 0.8.9, however,
+types in code are just padded normally.
 
 #### Code: data layout
 
@@ -164,11 +165,12 @@ Memory is a [padded location](#user-content-types-overview-overview-of-the-types
 direct types are padded as [described in their table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).
 Pointers, as mentioned above, always take up a full word.
 
-Note that immutables stored in memory have unusual padding; they are always
-zero-padded on the right, regardless of their usual padding.  Again, note that
-this only applies to immutables stored directly in memory during contract
-construct, and not to direct types appearing as elements of another type in
-memory in memory's normal use.
+Note that prior to Solidity 0.8.9, immutables stored in memory had unusual
+padding; they were always zero-padded on the right, regardless of their usual
+padding.  Again, note that this only applied to immutables stored directly in
+memory during contract construct, and not to direct types appearing as elements
+of another type in memory in memory's normal use.  Since Solidity 0.8.9, all
+direct types stored in memory, including immutables, have had normal padding.
 
 #### Layout of immutables in memory
 
@@ -180,8 +182,8 @@ Immutable state variables are stored one after the other starting at memory
 address `0x80` (skipping the first four words of memory as Solidity reserves
 these for internal purposes).  Memory being a padded location, each takes up
 one word (although note that as per the [previous
-subsection](#user-content-locations-in-detail-memory-in-detail-memory-direct-types-and-pointer-types)
-the padding on immutables is unusual).  This just leaves the question of the
+subsection](#user-content-locations-in-detail-memory-in-detail-memory-direct-types-and-pointer-types),
+the padding on immutables was unusual prior to Solidity 0.8.9).  This just leaves the question of the
 order that they are stored in.
 
 For the simple case of a contract without inheritance, the immutable state
@@ -473,6 +475,10 @@ The layout of direct types has already been described
 [above](#user-content-locations-in-detail-storage-in-detail-storage-data-layout), and the sizes of the direct types are found in the
 [direct types table](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types).  Note that there are [no pointer
 types in storage](#user-content-types-overview-overview-of-the-types-pointer-types).
+
+Note that in Solidity 0.8.8, there was a bug that caused user-defined value
+types to always take up a full word in storage, regardless of the size of the
+underlying type; values of these types would be padded as normal.
 
 #### Storage: Multivalue types
 

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -191,7 +191,7 @@ from "most base" to "most derived", and then, as mentioned above, lays out
 variables starting with the most base and ending with the most derived.
 (Remember that, when listing parent classes, Solidity considers parents listed
 *first* to be "more base"; as the [Solidity docs
-note](https://solidity.readthedocs.io/en/v0.7.1/contracts.html#multiple-inheritance-and-linearization),
+note](https://docs.soliditylang.org/en/v0.8.9/contracts.html#multiple-inheritance-and-linearization),
 this is the reverse order from, say, Python.)
 
 #### Memory: Multivalue types
@@ -333,12 +333,12 @@ the length of `msg.data` stored?  The answer, of course, is that this length is
 what is returned by the `CALLDATASIZE` instruction.  This instruction could be
 considered something of a special location, and indeed many of the Solidity
 language's special [globally available
-variables](https://docs.soliditylang.org/en/v0.8.7/units-and-global-variables.html)
+variables](https://docs.soliditylang.org/en/v0.8.9/units-and-global-variables.html)
 are "stored" in such special locations, each with their own EVM opcode.
 
 We have thus far ignored these special locations here and how they are encoded.
 However, since [the variables kept in these other special
-locations](https://docs.soliditylang.org/en/v0.8.7/units-and-global-variables.html#block-and-transaction-properties)
+locations](https://docs.soliditylang.org/en/v0.8.9/units-and-global-variables.html#block-and-transaction-properties)
 are all of type `uint256`, `address`, or `address payable`; these special locations are
 word-based rather than byte-based (to the extent that distinction is meaningful
 here); and values from these special locations will always be copied to the
@@ -462,7 +462,7 @@ from "most base" to "most derived", and then, as mentioned above, lays out
 variables starting with the most base and ending with the most derived.
 (Remember that, when listing parent classes, Solidity considers parents listed
 *first* to be "more base"; as the [Solidity docs
-note](https://docs.soliditylang.org/en/v0.8.7/contracts.html#multiple-inheritance-and-linearization),
+note](https://docs.soliditylang.org/en/v0.8.9/contracts.html#multiple-inheritance-and-linearization),
 this is the reverse order from, say, Python.)
 
 #### Storage: Direct types

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -42,7 +42,9 @@ constructor, and the contract has external functions other than the constructor,
 fallback, and receive functions, then
 the function selector will be stored on the stack below the first
 stackframe.  (Additionally, in Solidity 0.4.20 and later, an extra zero word
-will appear below that on the stack if you're within a library call.)
+will appear below that on the stack if you're within a library call, unless the
+function called is `pure` or `view` and does not include any storage pointers
+in its input or output parameters.)
 
 Note that function modifiers and base constructor invocations (whether placed
 on the constructor or on the contract) do not create new stackframes; these are

--- a/src/types.md
+++ b/src/types.md
@@ -21,9 +21,6 @@ consider as a separate type here.)
 This will be our fourfold division of types.  Some other type terminology, as
 defined by the language, is useful:
 
-*Value types* are certain specific direct types; see the [table of direct
-types](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types) for a list of which ones.
-
 The term *reference types* refers collectively to multivalue and lookup types.
 
 A *static type* is either
@@ -37,13 +34,10 @@ type, since, after all, there are no element variables.)
 A *dynamic type* is any type that is not static.  (Pointers don't fit into this
 dichotomy, not being an actual Solidity type.)
 
-Then there are the *elementary types*, which are relevant to mappings.  See the
+We'll also use the term *key types* to denote types that can be used as
+mapping keys.  See the
 [section on lookup types](#user-content-types-overview-overview-of-the-types-lookup-types) for more on
 these.
-
-(*Warning*: The Solidity documentation uses the term "elementary type" in
-several conflicting ways.  Here, it will always refer to a type that can be used
-as the key for a mapping, and not any of the other meanings.)
 
 Finally, to avoid confusion with other meanings of the word "value", I'm going
 to speak of "keys and elements" rather than "keys and values"; I'm going to
@@ -145,19 +139,19 @@ properties.  Some of this information may not yet make sense if you have only
 read up to this point.  See the [next section](#user-content-types-overview-overview-of-the-types-direct-types-representations-of-direct-types)
 for more detail on how these types are actually represented.
 
-| Type                | Size in storage (bytes)                     | Padding in most padded locations        | Default value                             | Is value type? | Is elementary? | Allowed in calldata? | Allowed as immutable?|
-|---------------------|---------------------------------------------|-----------------------------------------|-------------------------------------------|----------------|----------------|----------------------|----------------------|
-| `bool`              | 1                                           | Zero-padded, left                       | `false`                                   | Yes            | Yes            | Yes                  | Yes                  |
-| `uintN`             | N/8                                         | Zero-padded, left\*                     | 0                                         | Yes            | Yes            | Yes                  | Yes                  |
-| `intN`              | N/8                                         | Sign-padded, left\*                     | 0                                         | Yes            | Yes            | Yes                  | Yes                  |
-| `address [payable]` | 20                                          | Zero-padded, left\*                     | Zero address (not valid!)                 | Yes            | Yes            | Yes                  | Yes                  |
-| `contract` types    | 20                                          | Zero-padded, left\*                     | Zero address (not valid!)                 | No             | Yes            | Yes                  | Yes                  |
-| `bytesN`            | N                                           | Zero-padded, right\*                    | All zeroes                                | Yes            | Yes            | Yes                  | Yes                  |
-| `enum` types        | As many as needed to hold all possibilities | Zero-padded, left                       | Whichever possibility is represented by 0 | Yes            | Yes            | Yes                  | Yes                  |
-| `function internal` | 8                                           | Zero-padded, left                       | Depends on location, but always invalid   | No             | No             | No                   | Yes                  |
-| `function external` | 24                                          | Zero-padded, right, except on the stack | Zero address, zero selector (not valid!)  | No             | No             | Yes                  | No                   |
-| `ufixedMxN`         | M/8                                         | Zero-padded, left\*                     | 0                                         | Yes            | Yes            | Yes                  | Yes                  |
-| `fixedMxN`          | M/8                                         | Sign-padded, left\*                     | 0                                         | Yes            | Yes            | Yes                  | Yes                  |
+| Type                | Size in storage (bytes)                     | Padding in most padded locations        | Default value                             | Is key type? | Allowed in calldata? | Allowed as immutable?|
+|---------------------|---------------------------------------------|-----------------------------------------|-------------------------------------------|--------------|----------------------|----------------------|
+| `bool`              | 1                                           | Zero-padded, left                       | `false`                                   | Yes          | Yes                  | Yes                  |
+| `uintN`             | N/8                                         | Zero-padded, left\*                     | 0                                         | Yes          | Yes                  | Yes                  |
+| `intN`              | N/8                                         | Sign-padded, left\*                     | 0                                         | Yes          | Yes                  | Yes                  |
+| `address [payable]` | 20                                          | Zero-padded, left\*                     | Zero address (not valid!)                 | Yes          | Yes                  | Yes                  |
+| `contract` types    | 20                                          | Zero-padded, left\*                     | Zero address (not valid!)                 | Yes          | Yes                  | Yes                  |
+| `bytesN`            | N                                           | Zero-padded, right\*                    | All zeroes                                | Yes          | Yes                  | Yes                  |
+| `enum` types        | As many as needed to hold all possibilities | Zero-padded, left                       | Whichever possibility is represented by 0 | Yes          | Yes                  | Yes                  |
+| `function internal` | 8                                           | Zero-padded, left                       | Depends on location, but always invalid   | No           | No                   | Yes                  |
+| `function external` | 24                                          | Zero-padded, right, except on the stack | Zero address, zero selector (not valid!)  | No           | Yes                  | No                   |
+| `ufixedMxN`         | M/8                                         | Zero-padded, left\*                     | 0                                         | Yes          | Yes                  | Yes                  |
+| `fixedMxN`          | M/8                                         | Sign-padded, left\*                     | 0                                         | Yes          | Yes                  | Yes                  |
 
 Some remarks:
 
@@ -325,15 +319,12 @@ meaningfully speak of its elements.
 
 As mentioned above, mappings can go only in storage (but [see previous
 section](#user-content-types-overview-overview-of-the-types-multivalue-types) about mappings in structs).
-The key type for a mapping must be an elementary type, which means either:
-
-1. Either a value type or a `contract` type, or
-2. One of `string` or `bytes`.
-
-Observe that elementary types may all be meaningfully converted to a string of
-bytes.  Also, as an alternative to the above definition, one may see the
-appropriate tables to see which [direct](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types) or
-[lookup](#user-content-types-overview-overview-of-the-types-lookup-types-table-of-lookup-types) types are elementary.
+Only certain types are allowed as key types for mappings; these can roughly
+be described as the "value types" together with `string` and `bytes`, but one should see
+the appropriate tables to see which [direct](#user-content-types-overview-overview-of-the-types-direct-types-table-of-direct-types) or
+[lookup](#user-content-types-overview-overview-of-the-types-lookup-types-table-of-lookup-types) types are key types.
+Observe that key types may all be meaningfully converted to a string of
+bytes.
 
 The default value for a lookup type is for it to be empty.  For the particular
 case of a `type[]` in memory, the default value once it has been initialized to
@@ -343,12 +334,12 @@ The information above is also summarized in the following table.
 
 #### Table of lookup types
 
-| Type                              | Element type                                    | Restricted to storage? | Is elementary? |
-|-----------------------------------|-------------------------------------------------|------------------------|----------------|
-| `type[]`                          | `type`                                          | No                     | No             |
-| `mapping(keyType => elementType)` | `elementType`                                   | Yes                    | No             |
-| `bytes`                           | `byte` (`bytes1`)                               | No                     | Yes            |
-| `string`                          | N/A, but underlying `bytes` has `byte` elements | No                     | Yes            |
+| Type                              | Element type                                    | Restricted to storage? | Is key type? |
+|-----------------------------------|-------------------------------------------------|------------------------|--------------|
+| `type[]`                          | `type`                                          | No                     | No           |
+| `mapping(keyType => elementType)` | `elementType`                                   | Yes                    | No           |
+| `bytes`                           | `byte` (`bytes1`)                               | No                     | Yes          |
+| `string`                          | N/A, but underlying `bytes` has `byte` elements | No                     | Yes          |
 
 Note that mappings have other special features -- e.g., they cannot be copied or
 deleted -- but we will not go into that here.


### PR DESCRIPTION
Changes:

1. Added UDVTs.  Described the 0.8.8 bug.
2. Updated the descriptions of immutables.
3. Updated date, copyright, version, docs links.
4. Corrected a mistake about the delegatecall guard.
5. Eliminated references to "value types" as pointless.
6. Replaced "elementary type" with "key type" to reduce ambiguity.