### PR TITLE
Update notes about internal function representation

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -8,8 +8,8 @@ For writers of line debuggers and other debugging-related utilities.
 | Author | Harry Altman [@haltman-at] |
 | -----------:|:------------ |
 | Published | 2018-12-26 - Boxing Day |
-| Last revised | 2021-10-01 |
-| Copyright | 2018-2021 ConsenSys Software Inc |
+| Last revised | 2022-10-10 |
+| Copyright | 2018-2022 ConsenSys Software Inc |
 | License | <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a> |
 | Document Source | [ethdebug/solidity-data-representation](https://github.com/ethdebug/solidity-data-representation) |
 
@@ -44,5 +44,5 @@ original value in calldata will always be copied onto the stack before use).
 Obviously the value still exists in calldata, but since no variable points
 there, it's not our concern.
 
-_**Note**: This document pertains to **Solidity v0.8.9**, current as of this
+_**Note**: This document pertains to **Solidity v0.8.17**, current as of this
 writing._

--- a/src/intro.md
+++ b/src/intro.md
@@ -26,8 +26,8 @@ is not entirely predictable but may be determined by other
 systems of the debugger, we may rely on that.  See the
 [Solidity documentation](https://docs.soliditylang.org/) for things not
 covered here, particularly the
-[section on types](https://docs.soliditylang.org/en/v0.8.9/types.html)
-and the [ABI specification](https://docs.soliditylang.org/en/v0.8.9/types.html);
+[section on types](https://docs.soliditylang.org/en/v0.8.17/types.html)
+and the [ABI specification](https://docs.soliditylang.org/en/v0.8.17/types.html);
 and perhaps also see the [Ethereum yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf).
 
 This document is also primarily only concerned with variables that a user might

--- a/src/locations-detailed.md
+++ b/src/locations-detailed.md
@@ -195,7 +195,7 @@ from "most base" to "most derived", and then, as mentioned above, lays out
 variables starting with the most base and ending with the most derived.
 (Remember that, when listing parent classes, Solidity considers parents listed
 *first* to be "more base"; as the [Solidity docs
-note](https://docs.soliditylang.org/en/v0.8.9/contracts.html#multiple-inheritance-and-linearization),
+note](https://docs.soliditylang.org/en/v0.8.17/contracts.html#multiple-inheritance-and-linearization),
 this is the reverse order from, say, Python.)
 
 #### Memory: Multivalue types
@@ -337,12 +337,12 @@ the length of `msg.data` stored?  The answer, of course, is that this length is
 what is returned by the `CALLDATASIZE` instruction.  This instruction could be
 considered something of a special location, and indeed many of the Solidity
 language's special [globally available
-variables](https://docs.soliditylang.org/en/v0.8.9/units-and-global-variables.html)
+variables](https://docs.soliditylang.org/en/v0.8.17/units-and-global-variables.html)
 are "stored" in such special locations, each with their own EVM opcode.
 
 We have thus far ignored these special locations here and how they are encoded.
 However, since [the variables kept in these other special
-locations](https://docs.soliditylang.org/en/v0.8.9/units-and-global-variables.html#block-and-transaction-properties)
+locations](https://docs.soliditylang.org/en/v0.8.17/units-and-global-variables.html#block-and-transaction-properties)
 are all of type `uint256`, `address`, or `address payable`; these special locations are
 word-based rather than byte-based (to the extent that distinction is meaningful
 here); and values from these special locations will always be copied to the
@@ -466,7 +466,7 @@ from "most base" to "most derived", and then, as mentioned above, lays out
 variables starting with the most base and ending with the most derived.
 (Remember that, when listing parent classes, Solidity considers parents listed
 *first* to be "more base"; as the [Solidity docs
-note](https://docs.soliditylang.org/en/v0.8.9/contracts.html#multiple-inheritance-and-linearization),
+note](https://docs.soliditylang.org/en/v0.8.17/contracts.html#multiple-inheritance-and-linearization),
 this is the reverse order from, say, Python.)
 
 #### Storage: Direct types


### PR DESCRIPTION
Updates this document to discuss the representation of internal functions with `viaIR` turned on.